### PR TITLE
Add support for repeating a waveform in sync mode.

### DIFF
--- a/lib/pigpiox/waveform.ex
+++ b/lib/pigpiox/waveform.ex
@@ -115,6 +115,19 @@ defmodule Pigpiox.Waveform do
   end
 
   @doc """
+  Starts a repeating waveform in sync mode, by its id.
+
+  The sync mode waits for the current waveform to reach the end of a cycle or
+  finish before starting the new waveform.
+
+  Returns the number of DMA control blocks used in the waveform.
+  """
+  @spec repeat_sync(non_neg_integer) :: {:ok, non_neg_integer} | {:error, atom}
+  def repeat_sync(wave_id) do
+    Pigpiox.Socket.command(:waveform_transmit_mode, wave_id, 3)
+  end
+
+  @doc """
   Returns the length in microseconds of the current waveform.
   """
   @spec get_micros() :: {:ok, non_neg_integer} | {:error, atom}


### PR DESCRIPTION
Hi,

My use case for pigpiox requires the sync mode for waveforms (at least, I think it does!). I'm encoding a CPPM signal to relay to the trainer port of a FrSky Taranis in realtime.

I can handle the CPPM encoding part.

My questions are:

1. Is this PR on the right track? Should this be all that is needed to use sync mode? I'm not very familiar with pigpiod to be honest.
2. What's a good way to test this? I'm not quite sure on the exact behavioral difference for sync mode, but I think it's the way to go for a realtime loop.
3. If I want to send a new 22.5ms frame every 22.5ms, will the Elixir process "keep up" or do I need to be aware of issues with attempting a realtime feed?

Your help is greatly appreciated - and thank you for writing this library! 👍 