### PR TITLE
Add Waveform Chain command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,49 @@ Pigpiox.GPIO.set_mode(gpio, :output)
 Pigpiox.Waveform.repeat(wave_id)
 ```
 
+## Waveform chains
+
+You can compose more complex waveform by chaining them.
+For example, pulsing a GPIO on and off every 500 ms for 10 times and then 50 ms for 100 times and this forever. Chain can be nested.
+
+```elixir
+pulses_500 = [
+  %Pigpiox.Waveform.Pulse{gpio_on: gpio, delay: 500_000},
+  %Pigpiox.Waveform.Pulse{gpio_off: gpio, delay: 500_000}
+]
+
+Pigpiox.Waveform.add_generic(pulses_500)
+
+{:ok, wave_500} = Pigpiox.Waveform.create()
+
+pulses_50 = [
+  %Pigpiox.Waveform.Pulse{gpio_on: gpio, delay: 50_000},
+  %Pigpiox.Waveform.Pulse{gpio_off: gpio, delay: 50_000}
+]
+
+Pigpiox.Waveform.add_generic(pulses_50)
+
+{:ok, wave_50} = Pigpiox.Waveform.create()
+
+Pigpiox.GPIO.set_mode(gpio, :output)
+
+Pigpiox.Waveform.chain(%Pigpiox.Waveform.ChainElement{
+  content: [
+    %Pigpiox.Waveform.ChainElement{
+      content: [wave_500],
+      repeat: 10
+    },
+    %Pigpiox.Waveform.ChainElement{
+      content: [wave_50],
+      repeat: 100
+    }
+  ],
+  repeat: :forever
+})
+
+Pigpiox.Waveform.repeat(wave_id)
+```
+
 ## Clock
 
 The `Pigpiox.Clock` module provides functions that allow you to set a clock on reserved pin.

--- a/lib/pigpiox/socket.ex
+++ b/lib/pigpiox/socket.ex
@@ -32,22 +32,23 @@ defmodule Pigpiox.Socket do
   @doc """
   Runs a command via pigpiod.
   """
-  @spec command(type :: atom, param_one :: integer, param_two :: integer, extents :: list(integer)) :: command_result
-  def command(cmd, p1 \\ 0, p2 \\ 0, extents \\ [])
-  def command(cmd, p1, p2, extents) do
+  @spec command(type :: atom, param_one :: integer, param_two :: integer, extents :: list(integer), bits_size :: integer) :: command_result
+  def command(cmd, p1 \\ 0, p2 \\ 0, extents \\ [], bits_size \\ 32)
+  def command(cmd, p1, p2, extents, bits_size) do
     cmd_code = Pigpiox.Command.code(cmd)
-    GenServer.call(__MODULE__, {:do_command, cmd_code, p1, p2, extents})
+    GenServer.call(__MODULE__, {:do_command, cmd_code, p1, p2, extents, bits_size})
   end
 
-  @spec handle_call({:do_command, integer, integer, integer, list(integer)}, sender :: term, state) :: {:reply, command_result, state}
-  def handle_call({:do_command, command, p1, p2, extents}, _, socket) do
+  @spec handle_call({:do_command, integer, integer, integer, list(integer), integer}, sender :: term, state) :: {:reply, command_result, state}
+  def handle_call({:do_command, command, p1, p2, extents, bits_size}, _, socket) do
+    extents_length = length(extents) * round(bits_size / 8)
     base_msg  = <<command :: native-unsigned-integer-size(32),
                   p1 :: native-unsigned-integer-size(32),
                   p2 :: native-unsigned-integer-size(32),
-                  length(extents) * 4 :: native-unsigned-integer-size(32)>>
+                  extents_length :: native-unsigned-integer-size(32)>>
 
     msg = Enum.reduce(extents, base_msg, fn extent, accum ->
-      accum <> << extent :: native-unsigned-integer-size(32) >>
+      accum <> << extent :: native-unsigned-integer-size(bits_size) >>
     end)
     :ok = :gen_tcp.send(socket, msg)
     {

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,5 @@
-%{"dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}
+%{
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+}


### PR DESCRIPTION
You can compose more complex waveform by chaining them.
For example, pulsing a GPIO on and off every 500 ms for 10 times and then 50 ms for 100 times and this forever. Chain can be nested.

```elixir
pulses_500 = [
  %Pigpiox.Waveform.Pulse{gpio_on: gpio, delay: 500_000},
  %Pigpiox.Waveform.Pulse{gpio_off: gpio, delay: 500_000}
]

Pigpiox.Waveform.add_generic(pulses_500)

{:ok, wave_500} = Pigpiox.Waveform.create()

pulses_50 = [
  %Pigpiox.Waveform.Pulse{gpio_on: gpio, delay: 50_000},
  %Pigpiox.Waveform.Pulse{gpio_off: gpio, delay: 50_000}
]

Pigpiox.Waveform.add_generic(pulses_50)

{:ok, wave_50} = Pigpiox.Waveform.create()

Pigpiox.GPIO.set_mode(gpio, :output)

Pigpiox.Waveform.chain(%Pigpiox.Waveform.ChainElement{
  content: [
    %Pigpiox.Waveform.ChainElement{
      content: [wave_500],
      repeat: 10
    },
    %Pigpiox.Waveform.ChainElement{
      content: [wave_50],
      repeat: 100
    }
  ],
  repeat: :forever
})

Pigpiox.Waveform.repeat(wave_id)
```