### PR TITLE
Make hostname and socket configurable

### DIFF
--- a/lib/pigpiox/socket.ex
+++ b/lib/pigpiox/socket.ex
@@ -6,6 +6,9 @@ defmodule Pigpiox.Socket do
   Pigpiox.Socket provides an interface to send commands to a running pigpio daemon started by `Pigpiox.Port`
   """
 
+  @default_hostname 'localhost'
+  @default_port 8888
+
   @typep state :: :gen_tcp.socket
 
   @typedoc """
@@ -70,9 +73,11 @@ defmodule Pigpiox.Socket do
 
   @spec attempt_connection(retries :: non_neg_integer) :: {:ok, :gen_tcp.socket} | {:error, :could_not_connect}
   defp attempt_connection(num_retries) when num_retries > 0 do
-    _ = Logger.debug "Pigpiox.Socket: connecting to pigpiod"
+    hostname = Application.get_env(:pigpiox, :hostname, @default_hostname)
+    port = Application.get_env(:pigpiox, :port, @default_port)
+    _ = Logger.debug("Pigpiox.Socket: connecting to pigpiod #{hostname}:#{port}")
     opts = [:binary, active: false]
-    case :gen_tcp.connect('localhost', 8888, opts, 1000) do
+    case :gen_tcp.connect(hostname, port, opts, 1000) do
       {:ok, socket} -> {:ok, socket}
       {:error, _} ->
         Process.sleep(2000)


### PR DESCRIPTION
This allows us to run this in a non-nerves instances, just add `runtime: false` option to the deps line and add configuration.

closes #13  

```
config :pigpiox, hostname: 'somehost.local', port: 8888
```

And start all the children you will need, I suggest the socket and the watcher

To your application add the following children:
```
      {Pigpiox.Socket, [name: Pigpiox.Socket]},
      {Pigpiox.GPIO.WatcherSupervisor, []}
```

If config is left out it will try the default, localhost and 8888.


TODO Add some documentation to the README