### PR TITLE
Improve documentation for PWM

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ def deps(target) do
 
 # Usage
 
-Adding pigpiox as a dependency to your system will automatically launch the pigpio daemon and open a socket to communicate with it. To interact with pigpiod, Pigpiox provides various modules exposing different areas of functionality:
+Adding pigpiox as a dependency to your system will automatically launch the pigpio daemon and open a socket to communicate with it. To interact with pigpiod, Pigpiox provides various modules exposing different areas of functionality.
+
+All documentation available on [hexdocs](https://hexdocs.pm/pigpiox/).
 
 ## GPIO
 
@@ -77,7 +79,38 @@ The `Pigpiox.Clock` module provides functions that allow you to set a clock on r
 Pigpiox.Clock.hardware_clk(gpio, 2_500_000)
 ```
 
-All documentation available on [hexdocs](https://hexdocs.pm/pigpiox/).
+## Pulse-width modulation (PWM)
+
+The [`Pigpiox.Pwm` module](https://hexdocs.pm/pigpiox/Pigpiox.Pwm.html#content) provides functions that allow you to build and send waveforms with pigpiod.
+According to [Raspberry Pi's GPIO usage documentation](https://www.raspberrypi.org/documentation/usage/gpio/), here are the pins PWM is avaliable on:
+
+- Software PWM: all pins
+- Hardware PWM: GPIO12, GPIO13, GPIO18, GPIO19
+
+### Software PWM
+
+Max value for `level` is `255`. Here's an example of changing the brightness of an LED using software PWM.
+
+```elixir
+gpio = 12
+Pigpiox.Pwm.gpio_pwm(gpio, 255) # 100%
+Pigpiox.Pwm.gpio_pwm(gpio, 127) # 50%
+Pigpiox.Pwm.gpio_pwm(gpio, 25)  # 10%
+Pigpiox.Pwm.gpio_pwm(gpio, 2)   # 1%
+```
+
+### Hardware PWM
+
+Max value for `level` is `1_000_000`. Here's an example of changing the brightness of an LED using hardware PWM.
+
+```elixir
+gpio = 12
+frequency = 800
+Pigpiox.Pwm.hardware_pwm(gpio, frequency, 1_000_000) # 100%
+Pigpiox.Pwm.hardware_pwm(gpio, frequency, 500_000)   # 50%
+Pigpiox.Pwm.hardware_pwm(gpio, frequency, 100_000)   # 10%
+Pigpiox.Pwm.hardware_pwm(gpio, frequency, 10_000)    # 1%
+```
 
 # Contributions
 

--- a/lib/pigpiox/pwm.ex
+++ b/lib/pigpiox/pwm.ex
@@ -6,12 +6,12 @@ defmodule Pigpiox.Pwm do
   @moduledoc """
   Build and send waveforms with pigpiod.
   """
-  
+
   @doc """
-  Sets the current dutycycle and fequency for the hardware PWM on a specific GPIO `pin`
+  Sets the current dutycycle and fequency for the hardware PWM on a specific GPIO `pin`. Max value for `level` is `1_000_000`.
   """
   @spec hardware_pwm(pin :: integer, freq :: integer, level :: integer) :: :ok | {:error, atom}
-  def hardware_pwm(pin, freq, level) do
+  def hardware_pwm(pin, freq, level) when level in 0..1_000_000 do
     case Pigpiox.Socket.command(:hardware_pwm, pin, freq, [level]) do
       {:ok, _} -> :ok
       error -> error
@@ -19,10 +19,10 @@ defmodule Pigpiox.Pwm do
   end
 
   @doc """
-  Sets up a specific pin as a software PWM and sets the current dutycycle
+  Sets up a specific pin as a software PWM and sets the current dutycycle. Max value for `level` is `255`.
   """
   @spec gpio_pwm(pin :: integer, level :: integer) :: :ok | {:error, atom}
-  def gpio_pwm(pin, level) do
+  def gpio_pwm(pin, level) when level in 0..255 do
     case Pigpiox.Socket.command(:gpio_PWM, pin, level) do
       {:ok, _} -> :ok
       error -> error
@@ -62,4 +62,3 @@ defmodule Pigpiox.Pwm do
     end
   end
 end
-


### PR DESCRIPTION
First of all, thank you @tokafish for making such an awesome library!

This pull request is to improve the documentation for PWM. As a beginner myself, I was confused by a few thing when doing experiments with this library. So I just wanted to help other beginners quickly understand how to use this library.

**1. The link to the library's hexdoc (which is important to users) is at the very bottom of README.**
I bring the link to the Usage section. I think it will improve its discoverability.

**2. There is no example code for PWM.**
I add snippets that I actually used in dimming an LED. I guess most newbies are likely to want simple but concrete examples.

**3. The max value of `level` is different between software PWM and hardware PWM.**
I specify the max level value explicitly as guard clauses in code as well as mentioning it in the README.

I believe these little changes will help developer experience.

### Notes

#### software PWM

```elixir
# Allowed dutycycle: 0..255
Pigpiox.Pwm.gpio_pwm(12, -1)  #=> {:error, :bad_dutycycle}
Pigpiox.Pwm.gpio_pwm(12, 0)   #=> :ok
Pigpiox.Pwm.gpio_pwm(12, 255) #=> :ok
Pigpiox.Pwm.gpio_pwm(12, 256) #=> {:error, :bad_dutycycle}
```

The guard clause added will give the user a clue when a wrong value is passed in.

```elixir
iex(1)> Pigpiox.Pwm.gpio_pwm(12, -1)
** (FunctionClauseError) no function clause matching in Pigpiox.Pwm.gpio_pwm/2

    The following arguments were given to Pigpiox.Pwm.gpio_pwm/2:

        # 1
        12

        # 2
        -1

    Attempted function clauses (showing 1 out of 1):

        def gpio_pwm(pin, level) when is_integer(level) and (level >= 0 and level <= 255)

    (pigpiox 0.1.3) lib/pigpiox/pwm.ex:25: Pigpiox.Pwm.gpio_pwm/2
```

#### hardware PWM

```elixir
# Allowed dutycycle: 0..1_000_000
Pigpiox.Pwm.hardware_pwm(12, 800, -1)        #=> {:error, :bad_hpwm_duty}
Pigpiox.Pwm.hardware_pwm(12, 800, 0)         #=> :ok
Pigpiox.Pwm.hardware_pwm(12, 800, 1_000_000) #=> :ok
Pigpiox.Pwm.hardware_pwm(12, 800, 1_000_001) #=> {:error, :bad_hpwm_duty}
```

The guard clause added will give the user a clue when a wrong value is passed in.

```elixir
iex(1)> Pigpiox.Pwm.hardware_pwm(12, 800, 1_000_001)
** (FunctionClauseError) no function clause matching in Pigpiox.Pwm.hardware_pwm/3

    The following arguments were given to Pigpiox.Pwm.hardware_pwm/3:

        # 1
        12

        # 2
        800

        # 3
        1000001

    Attempted function clauses (showing 1 out of 1):

        def hardware_pwm(pin, freq, level) when is_integer(level) and (level >= 0 and level <= 1000000)

    (pigpiox 0.1.3) lib/pigpiox/pwm.ex:14: Pigpiox.Pwm.hardware_pwm/3
```