### PR TITLE
Add GPIO pull setting

### DIFF
--- a/lib/pigpiox/command.ex
+++ b/lib/pigpiox/command.ex
@@ -4,6 +4,7 @@ defmodule Pigpiox.Command do
   @commands %{
     set_mode:               0,
     get_mode:               1,
+    set_pull:               2,
     gpio_read:              3,
     gpio_write:             4,
     set_servo_pulsewidth:   8,

--- a/lib/pigpiox/gpio.ex
+++ b/lib/pigpiox/gpio.ex
@@ -12,6 +12,13 @@ defmodule Pigpiox.GPIO do
 	@gpio_modes Map.keys(@gpio_modes_map)
 	@inverted_gpio_modes_map for {key, val} <- @gpio_modes_map, into: %{}, do: {val, key}
 
+  @gpio_pull_map %{
+    off: 0,
+    down: 1,
+    up: 2
+  }
+  @gpio_pull Map.keys(@gpio_pull_map)
+
   @moduledoc """
   This module exposes pigpiod's basic GPIO functionality.
   """
@@ -20,6 +27,11 @@ defmodule Pigpiox.GPIO do
   A mode that a GPIO pin can be in. Returned by `get_mode/1` and passed to `set_mode/2`.
   """
   @type mode :: :input | :output | :alt0 | :alt1 | :alt2 | :alt3 | :alt4 | :alt5
+
+  @typedoc """
+  GPIO pull settings, for `set_pull/2`
+  """
+  @type pull :: :up | :down | :off
 
   @typedoc """
   The state of a GPIO pin - 0 for low, 1 for high.
@@ -50,6 +62,20 @@ defmodule Pigpiox.GPIO do
       error -> error
     end
 	end
+
+  @doc """
+  Sets a pull for a specific GPIO `pin`. `pin` must be a valid GPIO pin number for the device, with some exceptions.
+  See pigpio's [documentation](http://abyz.co.uk/rpi/pigpio/index.html) for more details.
+
+  `pull` can be any of `t:pull/0`.
+  """
+  @spec set_pull(pin :: integer, pull) :: :ok | {:error, atom}
+  def set_pull(pin, pull) when pull in @gpio_pull do
+    case Pigpiox.Socket.command(:set_pull, pin, @gpio_pull_map[pull]) do
+      {:ok, _} -> :ok
+      error -> error
+    end
+  end
 
   @doc """
   Returns the current level for a specific GPIO `pin`

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pigpiox.Mixfile do
   def project do
     [
       app: :pigpiox,
-      version: "0.1.2",
+      version: "0.1.3",
       elixir: "~> 1.5",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Allows setting the GPIO to be pull up/down or no pull. I have tested it on a Pi 4.